### PR TITLE
Document function visibility requirements

### DIFF
--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -33,12 +33,13 @@ Functions are the executable units of code within a contract.
 
 ::
 
+  @public
   @payable
-  function bid(): // Function
+  def bid(): // Function
     // ...
   }
 
 :ref:`function-calls` can happen internally or externally
 and have different levels of visibility (:ref:`visibility-and-getters`)
-towards other contracts.
+towards other contracts. Functions must be decorated with either @public or @internal.
 


### PR DESCRIPTION
### - What I did
Added documentation of @internal @public function structure requirement to "Structure of a Contract" section.

Also changed `function bid():` to `def bid():` That's correct right?

### - How I did it
As straightforwardly as I could

### - How to verify it
Read it.

### - Description for the changelog
Documentation update

### - Cute Animal Picture
![baby-animals-022](https://user-images.githubusercontent.com/471702/33005938-e44bf022-cd8d-11e7-8587-4cd66636f3cc.jpg)

